### PR TITLE
Tighten the constraints on the ring indicator view.

### DIFF
--- a/Sources/RoseChart/RoseChartView.swift
+++ b/Sources/RoseChart/RoseChartView.swift
@@ -119,9 +119,9 @@ public class RoseChartView: UIView {
         NSLayoutConstraint.activate([
             ringIndicatorView.heightAnchor.constraint(equalTo: ringIndicatorView.widthAnchor, multiplier: 1, constant: 0),
             ringIndicatorView.leftAnchor.constraint(greaterThanOrEqualTo: leftAnchor, constant: 0, priority: .defaultLow),
-            ringIndicatorView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: 0, priority: .defaultLow),
+            ringIndicatorView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: 0),
             ringIndicatorView.rightAnchor.constraint(greaterThanOrEqualTo: rightAnchor, constant: 0, priority: .defaultLow),
-            ringIndicatorView.bottomAnchor.constraint(greaterThanOrEqualTo: bottomAnchor, constant: 0, priority: .defaultLow),
+            ringIndicatorView.bottomAnchor.constraint(greaterThanOrEqualTo: bottomAnchor, constant: 0),
             ringIndicatorView.centerXAnchor.constraint(equalTo: centerXAnchor),
             ringIndicatorView.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])


### PR DESCRIPTION
The constraints allowed for the ring indicator view to grow beyond the
frame of the rose chart view. This is necessary to allow it to keep its
1:1 aspect ratio.

However, on very small sizes (or rather, certain aspect ratios), the view
would overflow the rose chart and not align with the background or
the graphs.

Increasing the priority on two constraints (top and bottom) allows it
to still overflow on the horizontal axis in case the aspect ratio is not
1:1 of the main view.